### PR TITLE
feature/add pre cxx flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ g++ -std=c++17 -Wall -Wextra -Isrc src/*.cpp -o bodge
 ### **Advanced Build System**
 - Cross-platform compatibility (Windows/Linux)
 - Static linking support to eliminate DLL dependencies
+- Pre-compilation flags (`pre_cxx_flags`) for SDK setup and early initialization
 - Comprehensive error handling and logging
 
 ### **Automatic Source Collection**
@@ -161,6 +162,20 @@ include_dirs: include
 libraries: pthread, m
 ```
 
+#### SDK Integration with Pre-CXX Flags:
+```
+name: Vulkan Project
+compiler: g++
+output_name: vulkan_app
+
+# Pre-flags are applied before sources (useful for SDK paths)
+pre_cxx_flags: -I$VULKAN_SDK/include, -L$VULKAN_SDK/lib
+cxx_flags: -std=c++17, -Wall, -O2
+
+sources: src/**
+libraries: vulkan
+```
+
 #### Legacy Configuration (Manual File Listing):
 ```
 name: MyProject
@@ -178,6 +193,7 @@ name: Multi-Target Project
 compiler: g++
 
 # Global settings for all targets
+global_pre_cxx_flags: -DEARLY_INIT
 global_cxx_flags: -std=c++17, -Wall, -static-libgcc, -static-libstdc++
 global_include_dirs: include
 
@@ -191,6 +207,7 @@ main.libraries: mylib
 mylib.type: shared
 mylib.output_name: mylib
 mylib.sources: src/lib/**
+mylib.pre_cxx_flags: -DLIB_EXPORTS
 mylib.cxx_flags: -O2, -fPIC
 
 # Static library target (automatic source collection)
@@ -215,6 +232,10 @@ compiler: g++
 
 # Build for multiple platforms
 platforms: windows_x64, linux_x64, windows_x86
+
+# Global platform-specific pre-flags (applied before sources)
+@windows.pre_cxx_flags: -IC:/SDK/include
+@linux.pre_cxx_flags: -I/usr/include/sdk
 
 # Global platform-specific settings
 @windows.cxx_flags: -static-libgcc, -static-libstdc++
@@ -252,6 +273,23 @@ app@linux_x64.output_suffix: _linux64
 - `unix_x86` / `unix_x64` - Unix 32-bit/64-bit
 - `apple_x86` / `apple_x64` - macOS 32-bit/64-bit
 - `*_arm` / `*_arm64` - ARM 32-bit/64-bit (any OS)
+
+### Compiler Flags Configuration
+Bodge provides two types of compiler flags for fine-grained control:
+
+- **`pre_cxx_flags`** - Applied **before** sources in the build command
+  - Perfect for SDK setup and early initialization
+  - Use for include paths that must be resolved before source compilation
+  - Example: `-I$VULKAN_SDK/include`, `-DSDK_EARLY_INIT`
+  
+- **`cxx_flags`** - Standard compiler flags applied after pre-flags
+  - Use for compilation options like `-std=c++17`, `-O2`, `-Wall`
+  - Applied in order: global → platform-specific → target-specific
+
+**Build Command Order:**
+```
+compiler → pre_cxx_flags → cxx_flags → includes → sources → output → libraries
+```
 
 ### Platform Configuration Syntax
 - `platforms: platform1, platform2` - Set default target platforms

--- a/src/Architecture.h
+++ b/src/Architecture.h
@@ -115,6 +115,7 @@ public:
  */
 struct PlatformConfig {
     Platform target_platform;
+    std::vector<std::string> pre_cxx_flags;  // Flags applied before sources
     std::vector<std::string> cxx_flags;
     std::vector<std::string> sources;
     std::vector<std::string> include_dirs;

--- a/src/BuildSystem.cpp
+++ b/src/BuildSystem.cpp
@@ -143,7 +143,8 @@ std::string BuildSystem::generate_command() const {
         return "";
     }
     
-    if (!validate_compiler_arguments(config_.cxx_flags) ||
+    if (!validate_compiler_arguments(config_.pre_cxx_flags) ||
+        !validate_compiler_arguments(config_.cxx_flags) ||
         !validate_compiler_arguments(config_.include_dirs) ||
         !validate_compiler_arguments(config_.sources) ||
         !validate_compiler_arguments(config_.library_dirs) ||
@@ -157,26 +158,29 @@ std::string BuildSystem::generate_command() const {
     // 1. Compiler
     command << config_.compiler;
 
-    // 2. Standard CXX Flags
+    // 2. Pre-CXX Flags (applied before everything else)
+    command << " " << StringUtils::join(config_.pre_cxx_flags, "", " ");
+
+    // 3. Standard CXX Flags
     command << " " << StringUtils::join(config_.cxx_flags, "", " ");
 
-    // 3. Include Directories (-I)
+    // 4. Include Directories (-I)
     command << StringUtils::join(config_.include_dirs, " -I", " ");
 
-    // 4. Source Files (must come before -o and linking flags)
+    // 5. Source Files (must come before -o and linking flags)
     command << StringUtils::join(config_.sources, "", " ");
 
-    // 5. Output file (-o)
+    // 6. Output file (-o)
     if (!is_safe_compiler_argument(config_.output_name)) {
         ProgressBar::display_error("Invalid output name specified");
         return "";
     }
     command << " -o " << config_.output_name;
 
-    // 6. Library Directories (-L)
+    // 7. Library Directories (-L)
     command << StringUtils::join(config_.library_dirs, " -L", " ");
 
-    // 7. Libraries (-l)
+    // 8. Libraries (-l)
     command << StringUtils::join(config_.libraries, " -l", " ");
 
     return command.str();
@@ -295,7 +299,9 @@ std::string BuildSystem::generate_target_command(const BuildTarget& target) cons
         return "";
     }
     
-    if (!validate_compiler_arguments(config_.global_cxx_flags) ||
+    if (!validate_compiler_arguments(config_.global_pre_cxx_flags) ||
+        !validate_compiler_arguments(config_.global_cxx_flags) ||
+        !validate_compiler_arguments(target.pre_cxx_flags) ||
         !validate_compiler_arguments(target.cxx_flags) ||
         !validate_compiler_arguments(config_.global_include_dirs) ||
         !validate_compiler_arguments(target.include_dirs) ||
@@ -313,13 +319,19 @@ std::string BuildSystem::generate_target_command(const BuildTarget& target) cons
     // 1. Compiler
     command << config_.compiler;
     
-    // 2. Global CXX Flags
+    // 2. Global Pre-CXX Flags
+    command << " " << StringUtils::join(config_.global_pre_cxx_flags, "", " ");
+    
+    // 3. Target-specific Pre-CXX Flags
+    command << " " << StringUtils::join(target.pre_cxx_flags, "", " ");
+    
+    // 4. Global CXX Flags
     command << " " << StringUtils::join(config_.global_cxx_flags, "", " ");
     
-    // 3. Target-specific CXX Flags
+    // 5. Target-specific CXX Flags
     command << " " << StringUtils::join(target.cxx_flags, "", " ");
     
-    // 4. Build type specific flags
+    // 6. Build type specific flags
     switch (target.type) {
         case BuildType::SHARED_LIBRARY:
 #ifdef _WIN32
@@ -337,16 +349,16 @@ std::string BuildSystem::generate_target_command(const BuildTarget& target) cons
             break;
     }
     
-    // 5. Global Include Directories (-I)
+    // 7. Global Include Directories (-I)
     command << StringUtils::join(config_.global_include_dirs, " -I", " ");
     
-    // 6. Target-specific Include Directories (-I)
+    // 8. Target-specific Include Directories (-I)
     command << StringUtils::join(target.include_dirs, " -I", " ");
     
-    // 7. Source Files
+    // 9. Source Files
     command << StringUtils::join(target.sources, "", " ");
     
-    // 8. Output file (-o)
+    // 10. Output file (-o)
     std::string output_name = target.output_name + target.get_output_extension();
     if (!is_safe_compiler_argument(output_name)) {
         ProgressBar::display_error("Invalid output name specified");
@@ -354,16 +366,16 @@ std::string BuildSystem::generate_target_command(const BuildTarget& target) cons
     }
     command << " -o " << output_name;
     
-    // 9. Global Library Directories (-L)
+    // 11. Global Library Directories (-L)
     command << StringUtils::join(config_.global_library_dirs, " -L", " ");
     
-    // 10. Target-specific Library Directories (-L)
+    // 12. Target-specific Library Directories (-L)
     command << StringUtils::join(target.library_dirs, " -L", " ");
     
-    // 11. Global Libraries (-l)
+    // 13. Global Libraries (-l)
     command << StringUtils::join(config_.global_libraries, " -l", " ");
     
-    // 12. Target-specific Libraries (-l)
+    // 14. Target-specific Libraries (-l)
     command << StringUtils::join(target.libraries, " -l", " ");
     
     return command.str();
@@ -548,7 +560,9 @@ std::string BuildSystem::generate_target_command_for_platform(const BuildTarget&
     PlatformConfig platform_config = target.get_platform_config(platform);
     
     // Validate all arguments
-    if (!validate_compiler_arguments(config_.global_cxx_flags) ||
+    if (!validate_compiler_arguments(config_.global_pre_cxx_flags) ||
+        !validate_compiler_arguments(config_.global_cxx_flags) ||
+        !validate_compiler_arguments(platform_config.pre_cxx_flags) ||
         !validate_compiler_arguments(platform_config.cxx_flags) ||
         !validate_compiler_arguments(config_.global_include_dirs) ||
         !validate_compiler_arguments(platform_config.include_dirs) ||
@@ -566,11 +580,26 @@ std::string BuildSystem::generate_target_command_for_platform(const BuildTarget&
     // 1. Compiler
     command << config_.compiler;
     
-    // 2. Global CXX Flags
+    // 2. Global Pre-CXX Flags
+    command << " " << StringUtils::join(config_.global_pre_cxx_flags, "", " ");
+    
+    // 3. Global platform-specific pre-flags
+    auto global_plat_it = config_.global_platform_configs.find(platform);
+    if (global_plat_it != config_.global_platform_configs.end()) {
+        if (!validate_compiler_arguments(global_plat_it->second.pre_cxx_flags)) {
+            ProgressBar::display_error("Invalid global platform-specific pre-compiler arguments");
+            return "";
+        }
+        command << " " << StringUtils::join(global_plat_it->second.pre_cxx_flags, "", " ");
+    }
+    
+    // 4. Target-specific Pre-CXX Flags (including platform-specific)
+    command << " " << StringUtils::join(platform_config.pre_cxx_flags, "", " ");
+    
+    // 5. Global CXX Flags
     command << " " << StringUtils::join(config_.global_cxx_flags, "", " ");
     
-    // 3. Global platform-specific flags
-    auto global_plat_it = config_.global_platform_configs.find(platform);
+    // 6. Global platform-specific flags
     if (global_plat_it != config_.global_platform_configs.end()) {
         if (!validate_compiler_arguments(global_plat_it->second.cxx_flags)) {
             ProgressBar::display_error("Invalid global platform-specific compiler arguments");
@@ -579,10 +608,10 @@ std::string BuildSystem::generate_target_command_for_platform(const BuildTarget&
         command << " " << StringUtils::join(global_plat_it->second.cxx_flags, "", " ");
     }
     
-    // 4. Target-specific CXX Flags (including platform-specific)
+    // 7. Target-specific CXX Flags (including platform-specific)
     command << " " << StringUtils::join(platform_config.cxx_flags, "", " ");
     
-    // 5. Build type specific flags
+    // 8. Build type specific flags
     switch (target.type) {
         case BuildType::SHARED_LIBRARY:
             if (platform.operating_system == OS::WINDOWS) {
@@ -600,10 +629,10 @@ std::string BuildSystem::generate_target_command_for_platform(const BuildTarget&
             break;
     }
     
-    // 6. Global Include Directories (-I)
+    // 9. Global Include Directories (-I)
     command << StringUtils::join(config_.global_include_dirs, " -I", " ");
     
-    // 7. Global platform-specific include directories
+    // 10. Global platform-specific include directories
     if (global_plat_it != config_.global_platform_configs.end()) {
         if (!validate_compiler_arguments(global_plat_it->second.include_dirs)) {
             ProgressBar::display_error("Invalid global platform-specific include directories");
@@ -612,13 +641,13 @@ std::string BuildSystem::generate_target_command_for_platform(const BuildTarget&
         command << StringUtils::join(global_plat_it->second.include_dirs, " -I", " ");
     }
     
-    // 8. Platform-specific Include Directories (-I)
+    // 11. Platform-specific Include Directories (-I)
     command << StringUtils::join(platform_config.include_dirs, " -I", " ");
     
-    // 9. Platform-specific Source Files
+    // 12. Platform-specific Source Files
     command << StringUtils::join(platform_config.sources, "", " ");
     
-    // 10. Output file (-o) with platform-specific suffix
+    // 13. Output file (-o) with platform-specific suffix
     std::string output_name = target.output_name + platform_config.output_name_suffix + target.get_output_extension(platform);
     if (!is_safe_compiler_argument(output_name)) {
         ProgressBar::display_error("Invalid output name specified");
@@ -626,10 +655,10 @@ std::string BuildSystem::generate_target_command_for_platform(const BuildTarget&
     }
     command << " -o " << output_name;
     
-    // 11. Global Library Directories (-L)
+    // 14. Global Library Directories (-L)
     command << StringUtils::join(config_.global_library_dirs, " -L", " ");
     
-    // 12. Global platform-specific library directories
+    // 15. Global platform-specific library directories
     if (global_plat_it != config_.global_platform_configs.end()) {
         if (!validate_compiler_arguments(global_plat_it->second.library_dirs)) {
             ProgressBar::display_error("Invalid global platform-specific library directories");
@@ -638,13 +667,13 @@ std::string BuildSystem::generate_target_command_for_platform(const BuildTarget&
         command << StringUtils::join(global_plat_it->second.library_dirs, " -L", " ");
     }
     
-    // 13. Platform-specific Library Directories (-L)
+    // 16. Platform-specific Library Directories (-L)
     command << StringUtils::join(platform_config.library_dirs, " -L", " ");
     
-    // 14. Global Libraries (-l)
+    // 17. Global Libraries (-l)
     command << StringUtils::join(config_.global_libraries, " -l", " ");
     
-    // 15. Global platform-specific libraries
+    // 18. Global platform-specific libraries
     if (global_plat_it != config_.global_platform_configs.end()) {
         if (!validate_compiler_arguments(global_plat_it->second.libraries)) {
             ProgressBar::display_error("Invalid global platform-specific libraries");
@@ -653,7 +682,7 @@ std::string BuildSystem::generate_target_command_for_platform(const BuildTarget&
         command << StringUtils::join(global_plat_it->second.libraries, " -l", " ");
     }
     
-    // 16. Platform-specific Libraries (-l)
+    // 19. Platform-specific Libraries (-l)
     command << StringUtils::join(platform_config.libraries, " -l", " ");
     
     return command.str();

--- a/src/ConfigParser.cpp
+++ b/src/ConfigParser.cpp
@@ -67,6 +67,8 @@ void ConfigParser::process_config_line(const std::string& line, ProjectConfig& c
         config.name = value_str;
     } else if (key == "compiler") {
         config.compiler = value_str;
+    } else if (key == "global_pre_cxx_flags") {
+        config.global_pre_cxx_flags = StringUtils::split(value_str, ',');
     } else if (key == "global_cxx_flags") {
         config.global_cxx_flags = StringUtils::split(value_str, ',');
     } else if (key == "global_include_dirs") {
@@ -85,6 +87,8 @@ void ConfigParser::process_config_line(const std::string& line, ProjectConfig& c
     // Legacy support
     else if (key == "output_name") {
         config.output_name = value_str;
+    } else if (key == "pre_cxx_flags") {
+        config.pre_cxx_flags = StringUtils::split(value_str, ',');
     } else if (key == "cxx_flags") {
         config.cxx_flags = StringUtils::split(value_str, ',');
     } else if (key == "sources") {
@@ -129,6 +133,8 @@ void ConfigParser::process_target_config_line(const std::string& key, const std:
     } else if (property == "sources") {
         std::vector<std::string> raw_sources = StringUtils::split(value, ',');
         target.sources = expand_sources(raw_sources);
+    } else if (property == "pre_cxx_flags") {
+        target.pre_cxx_flags = StringUtils::split(value, ',');
     } else if (property == "cxx_flags") {
         target.cxx_flags = StringUtils::split(value, ',');
     } else if (property == "include_dirs") {
@@ -249,7 +255,9 @@ void ConfigParser::process_platform_config_line(const std::string& key, const st
 }
 
 void ConfigParser::apply_platform_property(PlatformConfig& plat_config, const std::string& property, const std::string& value) {
-    if (property == "cxx_flags") {
+    if (property == "pre_cxx_flags") {
+        plat_config.pre_cxx_flags = StringUtils::split(value, ',');
+    } else if (property == "cxx_flags") {
         plat_config.cxx_flags = StringUtils::split(value, ',');
     } else if (property == "sources") {
         std::vector<std::string> raw_sources = StringUtils::split(value, ',');

--- a/src/ProjectConfig.cpp
+++ b/src/ProjectConfig.cpp
@@ -27,6 +27,7 @@ PlatformConfig BuildTarget::get_platform_config(const Platform& platform) const 
     PlatformConfig config(platform);
     
     // Start with base configuration
+    config.pre_cxx_flags = pre_cxx_flags;
     config.cxx_flags = cxx_flags;
     config.sources = sources;
     config.include_dirs = include_dirs;
@@ -41,6 +42,9 @@ PlatformConfig BuildTarget::get_platform_config(const Platform& platform) const 
     for (const auto& [plat, plat_config] : platform_configs) {
         if (plat.matches(platform)) {
             // Merge configurations (platform-specific takes precedence)
+            if (!plat_config.pre_cxx_flags.empty()) {
+                config.pre_cxx_flags.insert(config.pre_cxx_flags.end(), plat_config.pre_cxx_flags.begin(), plat_config.pre_cxx_flags.end());
+            }
             if (!plat_config.cxx_flags.empty()) {
                 config.cxx_flags.insert(config.cxx_flags.end(), plat_config.cxx_flags.begin(), plat_config.cxx_flags.end());
             }
@@ -169,6 +173,7 @@ void ProjectConfig::convert_legacy_to_targets() {
     default_target.name = "default";
     default_target.type = BuildType::EXECUTABLE;
     default_target.output_name = output_name;
+    default_target.pre_cxx_flags = pre_cxx_flags;
     default_target.cxx_flags = cxx_flags;
     default_target.sources = sources;
     default_target.include_dirs = include_dirs;

--- a/src/ProjectConfig.h
+++ b/src/ProjectConfig.h
@@ -47,6 +47,7 @@ struct BuildTarget {
     std::string name;
     BuildType type;
     std::string output_name;
+    std::vector<std::string> pre_cxx_flags;  // Flags applied before sources
     std::vector<std::string> cxx_flags;
     std::vector<std::string> sources;
     std::vector<std::string> include_dirs;
@@ -94,6 +95,7 @@ struct ProjectConfig {
     std::string compiler;
     
     // Global defaults
+    std::vector<std::string> global_pre_cxx_flags;  // Flags applied before sources
     std::vector<std::string> global_cxx_flags;
     std::vector<std::string> global_include_dirs;
     std::vector<std::string> global_library_dirs;
@@ -116,6 +118,7 @@ struct ProjectConfig {
     
     // Legacy support - converted to default target
     std::string output_name;
+    std::vector<std::string> pre_cxx_flags;
     std::vector<std::string> cxx_flags;
     std::vector<std::string> sources;
     std::vector<std::string> include_dirs;

--- a/src/core.h
+++ b/src/core.h
@@ -4,7 +4,7 @@
 #define CORE_H
 
 // Version of the build system
-#define VERSION "1.0.3.4"
+#define VERSION "1.1.0.0"
 
 // Function to get the version string
 const char* get_version();


### PR DESCRIPTION
This is linked to Issue: https://github.com/el-dockerr/bodge/issues/14

```
g++  -I C:\VulkanSDK\1.4.328.1\Include C:\Windows\System32\vulkan-1.dll -I C:\GLFW\glfw-3.4.bin.WIN64\include -L C:\GLFW\glfw-3.4.bin.WIN64\lib-mingw-w64 -lglfw3 -lgdi32 -luser32  -std=c++17 -Wall -Wextra -Wpedantic...
```

A Vulkan/LGLFW compilation command has the correct structure for MinGW, but you are hitting the classic linker error: The library file must appear AFTER the source files or object files that depend on it.

The linker processes arguments from left to right. When it sees your source file, it notes all the undefined references (glfwInit, glfwCreateWindow, etc.). If it hasn't seen the GLFW library yet, it can't resolve those symbols, and the build fails.

The fix is simply a matter of reordering the elements in your command line. Therefore Bodge must have a representation for those orders to achieve more compatibility.

### 🛠️ The Corrected Command Order
Move the source file (src\main.cpp) and the Vulkan DLL path to the beginning, followed by all the GLFW and system library linking flags (-L and -l).

### ❌ Original (Failed) Order
```
g++ -I... C:\Windows\System32\vulkan-1.dll -I... -L C:\GLFW\... -lglfw3 -lgdi32 -luser32 src\main.cpp -o...
// Problem: The linker sees -lglfw3 AFTER src\main.cpp, but main.cpp needs glfw3 references resolved immediately.
```

✅ Correct (Working) Order
```
g++ -std=c++17 -Wall -Wextra -Wpedantic -O2 -m64 -static-libgcc -static-libstdc++ \
-I C:\VulkanSDK\1.4.328.1\Include \
-I C:\GLFW\glfw-3.4.bin.WIN64\include \
src\main.cpp \
C:\Windows\System32\vulkan-1.dll \
-L C:\GLFW\glfw-3.4.bin.WIN64\lib-mingw-w64 \
-lglfw3 -lgdi32 -luser32 \
-o vulcan_test.exe
```